### PR TITLE
Fix crash on credentials retrieval failure

### DIFF
--- a/tuijam/app.py
+++ b/tuijam/app.py
@@ -125,12 +125,21 @@ class App(urwid.Pile):
         self.g_api.oauth_login(self.g_api.FROM_MAC_ADDRESS, CRED_FILE)
 
         if self.lastfm_sk is not None:
-            self.lastfm = LastFMAPI(self.lastfm_sk)
+            try:
+                self.lastfm = LastFMAPI(self.lastfm_sk)
+            except Exception:
+                print("Could not retrieve Last.fm keys.")
+                print("Scrobbling will not be available.")
             # TODO handle if sk is invalid
 
         from apiclient.discovery import build
-        developer_key, = lookup_keys("GOOGLE_DEVELOPER_KEY")
-        self.youtube = build("youtube", "v3", developerKey=developer_key)
+        try:
+            developer_key, = lookup_keys("GOOGLE_DEVELOPER_KEY")
+            self.youtube = build("youtube", "v3", developerKey=developer_key)
+        except Exception:
+            print("Could not retrieve YouTube key.")
+            print("YouTube will not be available.")
+            self.video = False
 
     def load_config(self):
         if not isfile(CONFIG_FILE):
@@ -381,6 +390,8 @@ class App(urwid.Pile):
         location=None,
         location_radius=None,
     ):
+        if not self.video:
+            return None, []
         """
         Mostly stolen from: https://github.com/spnichol/youtube_tutorial/blob/master/youtube_videos.py
         """


### PR DESCRIPTION
Nothing special, just a fix for #39 

Also I must say that a launch of TUIJam with an empty file named `google_oauth.cred` works *exactly* like with a file with real token.