### PR TITLE
Control expand_full 'E' to load full playlist with more than 30 items.

### DIFF
--- a/tuijam/app.py
+++ b/tuijam/app.py
@@ -357,7 +357,7 @@ class App(urwid.Pile):
         else:
             super().mouse_event(size, event, button, col, row, focus=focus)
 
-    def expand(self, obj):
+    def expand(self, obj, no_limit=False):
         if obj is None:
             return
 
@@ -402,7 +402,10 @@ class App(urwid.Pile):
 
         elif isinstance(obj, RadioStation):
             station_id = obj.get_station_id(self.g_api)
-            songs = self.get_radio_songs(station_id)
+            if no_limit:
+                songs = self.get_radio_songs(station_id,n=150)
+            else:
+                songs = self.get_radio_songs(station_id)
             radio_stations = [obj]
 
         elif isinstance(obj, Playlist):
@@ -413,7 +416,7 @@ class App(urwid.Pile):
             yt_vids = [obj]
 
         self.search_panel.update_search_results(
-            songs, albums, artists, situations, radio_stations, playlists, yt_vids
+            songs, albums, artists, situations, radio_stations, playlists, yt_vids, no_limit=no_limit
         )
 
     def youtube_search(

--- a/tuijam/ui.py
+++ b/tuijam/ui.py
@@ -32,8 +32,6 @@ RATE_UI = {
     5: "▲",  # Thumbs up
 }
 
-DEFAULT_SEARCH_LIMIT = 10_000
-
 palette = {
     "header": ["white,underline", "default"],
     "search-normal": ["white", "default"],
@@ -61,6 +59,7 @@ controls = dict(
     down="j",
     up="k",
     expand=["e", "enter"],
+    expand_full=["E"],
     seek_pos=[">", "shift right"],
     seek_neg=["<", "shift left"],
     vol_up=["+", "="],
@@ -145,6 +144,7 @@ class SearchPanel(urwid.ListBox):
         self.search_results = self.SearchResults([])
         self.line_box = None
         self.viewing_previous_songs = False
+        self.no_limit = False
 
         super().__init__(self.walker)
 
@@ -179,6 +179,9 @@ class SearchPanel(urwid.ListBox):
         elif key in controls["expand"]:
             if self.selected_search_obj() is not None:
                 self.app.expand(self.selected_search_obj())
+        elif key in controls["expand_full"]:
+            if self.selected_search_obj() is not None:
+                self.app.expand(self.selected_search_obj(),no_limit=True)
         elif key in controls["back"]:
             self.back()
         elif key in controls["radio"]:
@@ -205,7 +208,7 @@ class SearchPanel(urwid.ListBox):
                 pass
 
     def update_search_results(
-        self, *categories, title=None, isprevsong=False
+        self, *categories, title=None, isprevsong=False, no_limit=False
     ):
         if title is None:
             title = _("Search Results")
@@ -214,6 +217,7 @@ class SearchPanel(urwid.ListBox):
             self.search_history.append((self.get_focus()[1], self.search_results))
 
         self.viewing_previous_songs = isprevsong
+        self.no_limit = no_limit
 
         self.set_search_results(categories)
         self.line_box.set_title(title)
@@ -224,10 +228,11 @@ class SearchPanel(urwid.ListBox):
         )
 
     def set_search_results(self, categories):
-        def filter_none(lst, limit=DEFAULT_SEARCH_LIMIT):
+        def filter_none(lst, limit=30):
             filtered = [obj for obj in lst if obj is not None]
-
-            if self.viewing_previous_songs:
+            
+            if (self.viewing_previous_songs) or (self.no_limit):
+                self.no_limit = False
                 return filtered
             else:
                 return filtered[:limit]


### PR DESCRIPTION
I have some long playlists and was only getting the most recently added 30 songs when playing them. I added a control expand_full=["E"] to load the full playlist. 

Can also be used on a station to load up to 150 songs instead of 50. 

First commit can be ignored. I was just going to bump the limit and not create a pull request, but then decided to add the shortcut and create a pull request in case others would use it. 

Thanks for creating tuijam! I ❤️ playing my jams with tuijam!